### PR TITLE
Fix Error 404 related errors when using React Router 

### DIFF
--- a/configs/webpack/dev.js
+++ b/configs/webpack/dev.js
@@ -13,6 +13,7 @@ module.exports = merge(commonConfig, {
   ],
   devServer: {
     hot: true, // enable HMR on the server
+    historyApiFallback: true, // fixes error 404-ish errors when using react router :see this SO question: https://stackoverflow.com/questions/43209666/react-router-v4-cannot-get-url 
   },
   devtool: "cheap-module-source-map",
   plugins: [


### PR DESCRIPTION
When using React Router: Refresh and links don't work smoothly: gives error cannot `GET /some-path`